### PR TITLE
Add realtime gateway status from TTN status API

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
         <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
         <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap-theme.min.css">
 
-        <link href="static/page.css?v=2" rel="stylesheet" />
+        <link href="static/page.css?v=3" rel="stylesheet" />
     </head>
 
     <body role="document">
@@ -64,7 +64,7 @@
         
         <script src="https://maps.googleapis.com/maps/api/js"></script>
         
-        <script src="static/page.js?v=2"></script>
+        <script src="static/page.js?v=3"></script>
         
         <script>
           (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
If a gateway has `gateway_eui` in the data, we can lookup the up/down status on TTN.

The change is really small, use `?w=1` on the URL to see the diff ignoring whitespace change (indented a lot due to callback).
